### PR TITLE
chore: add markdown issue template files as yml issue template files only work in public repositories

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,25 @@
+---
+name: 'Bug Report'
+about: File a bug report
+title: "[Bug]: "
+labels: 'status:triage'
+---
+
+<!---
+Before you submit, please read the following:
+
+Search open/closed issues before submitting. Someone may have reported the same issue before.
+-->
+
+# Bug Report
+
+## What Happened?
+
+<!--- Please provide steps to reproduce the bug, what happened and what you expected to have happen. If possible, also include ideas for a solution. -->
+
+## Your Environment
+
+<!--- Include as many relevant details as possible about the environment you experienced the bug in -->
+
+* OS & Device: [e.g. MacOS, iOS, Windows, Linux] on [iPhone 7, PC]
+* Browser [e.g. Microsoft Edge, Google Chrome, Apple Safari, Mozilla FireFox]

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Add a feature to FAST Creator
+title: "[Feature]: "
+labels: 'status:triage'
+---
+
+<!---
+Before you submit, please read the following:
+
+Search open/closed issues before submitting. Someone may have requested the same feature before.
+-->
+
+# Feature Request
+
+## Summary
+
+<!--- Provide a general summary of the feature here -->
+
+## Examples
+
+<!-- Examples help us understand the requested feature better -->
+<!-- Attach screenshots or images if they would add detail to your request -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+# Pull Request
+
+## 📖 Description
+
+<!--- Provide some background and a description of your work. -->
+
+### 🎫 Issues
+
+<!---
+List and link relevant issues here using the keyword "closes"
+if this PR will close an issue, eg. closes #411
+-->
+
+## 👩‍💻 Reviewer Notes
+
+<!---
+Provide some notes for reviewers to help them provide targeted feedback and testing.
+-->
+
+## ✅ Checklist
+
+### General
+
+<!--- Review the list and put an x in the boxes that apply. -->
+
+- [ ] I have added tests for my changes.
+- [ ] I have tested my changes.
+- [ ] I have updated the project documentation to reflect my changes.
+
+## ⏭ Next Steps
+
+<!---
+If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
+-->


### PR DESCRIPTION
Adding markdown issue template files to provide some scaffolding to the issue filing for this repository.