### PR TITLE
update copy command on continous delivery configuration

### DIFF
--- a/.github/workflows/cd-create-stage.yml
+++ b/.github/workflows/cd-create-stage.yml
@@ -23,6 +23,8 @@ jobs:
 
     - name: Build & Prepare Web Application
       run: |
+        npm ci
+        npm run build
         cp build/server/* www
         cd www
         npm ci


### PR DESCRIPTION
# Pull Request

## 📖 Description
A pipeline failure on `www` folder not found was breaking the GitHub Action and preventing continuous delivery to staging websites.

Note: It was faster to start a new PR, rather than fight through the package-lock issue.

### 🎫 Issues
* No issue #, just found during testing

## 👩‍💻 Reviewer Notes
Will test prior to merging this in to ensure that site releases are working

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps
N/A
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->