### PR TITLE
Remove the reference to the release branch in the workflow during validation and deploy

### DIFF
--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -18,8 +18,6 @@ jobs:
     
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: release
     - name: Cache multiple paths
       uses: actions/cache@v2
       env:


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This causes the build step to build the release branch for the deployed artifact and not the PR branch that triggered the workflow.

See: https://github.com/actions/checkout#usage

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
This should enable PRs such as #67 to show the feature work in the deployed site.