### PR TITLE
Fix inline edit empty string bug

### DIFF
--- a/app/creator.tsx
+++ b/app/creator.tsx
@@ -560,7 +560,7 @@ class Creator extends Editor<{}, CreatorState> {
                         originatorId: htmlRenderOriginatorId,
                     },
                 });
-            } else if (e.data.data) {
+            } else if (e.data.data || e.data.data === "") {
                 this.fastMessageSystem.postMessage({
                     type: MessageSystemType.data,
                     action: MessageSystemDataTypeAction.update,
@@ -633,7 +633,6 @@ class Creator extends Editor<{}, CreatorState> {
             } catch (e) {
                 messageData = null;
             }
-
             if (
                 messageData &&
                 messageData.type === MessageSystemType.dataDictionary &&


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
The Creator message handling logic was ignoring edit messages when the new value was an empty string. 

**This will not be full fixed until after https://github.com/microsoft/fast-tooling/pull/136 is merged and the fast-tooling version dependency is updated.**

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->