### PR TITLE
Add a check for explicit user interaction when updating navigation in monaco editor

### DIFF
--- a/app/site-utilities/components/editor/index.tsx
+++ b/app/site-utilities/components/editor/index.tsx
@@ -24,6 +24,7 @@ import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 import { StandardLuminance } from "@microsoft/fast-components";
 import { classNames, Direction } from "@microsoft/fast-web-utilities";
 import FASTMessageSystemWorker from "@microsoft/fast-tooling/dist/message-system.min.js";
+import { rootOriginatorId } from "../../../utilities";
 import { EditorState } from "./editor.props";
 
 export const previewBackgroundTransparency: string = "PREVIEW::TRANSPARENCY";
@@ -168,7 +169,11 @@ abstract class Editor<P, S extends EditorState> extends React.Component<P, S> {
             );
             this.editor.onDidChangeCursorPosition(
                 (e: monaco.editor.ICursorPositionChangedEvent): void => {
-                    if (Array.isArray(this.monacoValue) && this.monacoValue[0]) {
+                    if (
+                        e.reason === 3 &&
+                        Array.isArray(this.monacoValue) &&
+                        this.monacoValue[0]
+                    ) {
                         const dictionaryId = findDictionaryIdByMonacoEditorHTMLPosition(
                             e.position,
                             this.state.dataDictionary,
@@ -182,6 +187,9 @@ abstract class Editor<P, S extends EditorState> extends React.Component<P, S> {
                                 action: MessageSystemNavigationTypeAction.update,
                                 activeDictionaryId: dictionaryId,
                                 activeNavigationConfigId: "",
+                                options: {
+                                    originatorId: rootOriginatorId,
+                                },
                             });
                         }
                     }


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change checks the reason for a cursor position update inside the Monaco Editor, the reason `3` means a user action was taken, this ensures that navigation is not updated unnecessarily.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->
This was an issue in #76 and has been tested against it, to see the exact problem you may need to cherry pick this on top of that branch.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.