### PR TITLE
Fixed an issue where the position change during monaco editor content selection caused navigation updates

### DIFF
--- a/app/site-utilities/components/editor/index.tsx
+++ b/app/site-utilities/components/editor/index.tsx
@@ -60,7 +60,7 @@ abstract class Editor<P, S extends EditorState> extends React.Component<P, S> {
     private adapter: MonacoAdapter;
     private monacoEditorModel: monaco.editor.ITextModel;
     private firstRun: boolean = true;
-    private positionUpdateTimer: XOR<number, NodeJS.Timer>;
+    private positionUpdateTimeout: XOR<number, NodeJS.Timer>;
 
     constructor(props: P) {
         super(props);
@@ -171,11 +171,11 @@ abstract class Editor<P, S extends EditorState> extends React.Component<P, S> {
             );
             this.editor.onDidChangeCursorPosition(
                 (e: monaco.editor.ICursorPositionChangedEvent): void => {
-                    if (this.positionUpdateTimer) {
-                        clearTimeout(this.positionUpdateTimer as number);
+                    if (this.positionUpdateTimeout) {
+                        clearTimeout(this.positionUpdateTimeout as number);
                     }
 
-                    this.positionUpdateTimer = setTimeout(
+                    this.positionUpdateTimeout = setTimeout(
                         this.updateNavigation.bind(this, e),
                         500
                     );


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
The navigation updates were firing every time the position changed in monaco editor. This is undesirable in situations where the user is attempting to copy/paste code, so a setTimeout has been added to account for that interaction.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->
Try adding multiple cards with content and copy pasting them, this should now work without the added jitter in the monaco editor.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
