### PR TITLE
Update documentation and workflows to use 'stage' branch instead of 'release'

### DIFF
--- a/.github/workflows/cd-deploy-staging.yml
+++ b/.github/workflows/cd-deploy-staging.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - release
+    - stage
 
 env:
   ARTIFACT_NAME: creator-app-stage
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        ref: release
+        ref: stage
     - uses: actions/cache@v2
       env:
         cache-name: cache-node-modules

--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -3,11 +3,11 @@ name: Validate
 on:
   push:
     branches: 
-      - release
+      - stage
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
-      - release 
+      - stage 
 
 jobs:
   build:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ Creator will now use your local copy of FAST Tooling and any changes made and bu
 
 ### Submitting a pull request
 
-If you'd like to contribute by fixing a bug, implementing a feature, or even correcting typos in our documentation, you'll want to submit a pull request. Before submitting a pull request, be sure to [rebase](https://www.atlassian.com/git/tutorials/merging-vs-rebasing) your branch from `release` or use the *merge* button provided by GitHub.
+If you'd like to contribute by fixing a bug, implementing a feature, or even correcting typos in our documentation, you'll want to submit a pull request. Before submitting a pull request, be sure to [rebase](https://www.atlassian.com/git/tutorials/merging-vs-rebasing) your branch from `stage` or use the *merge* button provided by GitHub.
 When submitting your pull request please make the title clear and concise, provide a description of the change, and specify the issue that will be closed.
 
 ### DevOps

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -1,6 +1,6 @@
 # Process
 
-This document outlines the release process for the Creator application. It details short and long term planning, the relationship between the Creator application repository and the FAST tooling repository and the participants involved and their roles.
+This document outlines the process to complete milestones for the Creator application. It details short and long term planning, the relationship between the Creator application repository and the FAST tooling repository and the participants involved and their roles.
 
 ## Participants
 
@@ -20,22 +20,22 @@ This document outlines the release process for the Creator application. It detai
 
 ## Planning cadence
 
-There are two main planning cadences, a short term weekly planning cadence (similar to the current architecture and tooling planning, which will have a short high-level summary from the earlier tooling meeting) and a longer term cadence so that the Creator can move through such stages as alpha, beta, release candidate and so forth. The longer term cadences will become milestones and the work will be done in a `release` branch.
+There are two main planning cadences, a short term weekly planning cadence (similar to the current architecture and tooling planning, which will have a short high-level summary from the earlier tooling meeting) and a longer term cadence so that the Creator can move through such stages as alpha, beta, release candidate and so forth. The longer term cadences will become milestones and the work will be done in a `stage` branch.
 
-## Planning a release
+## Planning a milestone
 
-- A new release should start being planned approximately 2 weeks before the end of the previous release, check the estimated amount of time remaining during the weekly planning meetings.
-- User testing will be planned at the beginning of the release.
+- A new milestone should start being planned approximately 2 weeks before the end of the previous milestone, check the estimated amount of time remaining during the weekly planning meetings.
+- User testing will be planned at the beginning of the milestone.
 - A milestone will be created in the fast-creator repository and a milestone with the same name will be created in the fast-tooling repository.
-    - The name of the milestone should be a simple number, such as "Release 1".
-    - The release description in the fast-creator repository should include the release version e.g. "alpha".
-- Identify and place all new ideas and features for the release into a milestone
-    - A release does not need to include a major change, but should include a set of features and bugs in a coherent grouping or based on priority.
-- When all issues placed in a milestone for a release are resolved that `release` branch should be merged to the `main` branch.
+    - The name of the milestone should be a simple number, such as "1".
+    - The milestone description in the fast-creator repository should include the milestone version e.g. "alpha".
+- Identify and place all new ideas and features into the milestone
+    - A milestone does not need to include a major change, but should include a set of features and bugs in a coherent grouping or based on priority.
+- When all issues placed in a milestone are resolved, the `stage` branch should be merged to the `main` branch.
     - This should result in a publish to production.
-    - The changelog for new releases should be generated via beachball.
-        - This may at some point become part of the app, similar to how other apps have a notification with "what's new in this version" pop up.
-- The milestone for the release is closed.
+    - The changelog for new milestones should be generated via beachball.
+        - This is integrated as part of the app as a "what's new in this version" pop up.
+- The milestone is closed.
 - A milestone retrospective is conducted.
 
 ## Planning a feature
@@ -66,7 +66,7 @@ Feature planning includes converting `idea` issues into issues, gathering requir
 - Completing a design issue
     - Provide a link to the design file
         - Link to the figma file in Creator if the issue is part of the Creator repository.
-        - Link to the figma file in the Creator release issue tracker under the linked issue if the issue is part of the FAST tooling repository and provide a `.png` file for the FAST tooling issue.
+        - Link to the figma file in the Creator milestone issue tracker under the linked issue if the issue is part of the FAST tooling repository and provide a `.png` file for the FAST tooling issue.
     - Get sign off from the developer developing the related feature issue.
     - Close the issue.
     - Remove the `status:blocked` tag from related the developer feature issue
@@ -79,7 +79,7 @@ Feature planning includes converting `idea` issues into issues, gathering requir
 
 ### User testing
 
-During a release 2 users will be consulted for user testing. This will come in the form of 2 separate meetings in which the user will be prompted with a task and recorded during the session. The video will then be posted to this [channel](https://msit.microsoftstream.com/channel/ca8b0840-98dc-948e-a12d-f1ec27b5c313) and sent to product managers for review. The bugs and features resulting from the user testing will be filed as issues in either FAST Creator or FAST Tooling by @janechu. The next release milestone will be created at this time to place bugs and/or features into.
+During a milestone 2 users will be consulted for user testing. This will come in the form of 2 separate meetings in which the user will be prompted with a task and recorded during the session. The video will then be posted to this [channel](https://msit.microsoftstream.com/channel/ca8b0840-98dc-948e-a12d-f1ec27b5c313) and sent to product managers for review. The bugs and features resulting from the user testing will be filed as issues in either FAST Creator or FAST Tooling by @janechu. The next milestone will be created at this time to place bugs and/or features into.
 
 ### Milestone retrospective
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
The purpose of this update is to change all references to `release` branch to `stage`. This will alleviate confusion that was occurring as `stage` branch is always a reflection of what is on the staging server.

This pull request updates:
- Automated workflows
- Documentation

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->
Closes #88

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->
Check to see that the stage static site deployment is still working and that the wording in the documentation is correct.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.