### PR TITLE
Fix production instance to eliminate 503 error

### DIFF
--- a/build/server/server.js
+++ b/build/server/server.js
@@ -43,16 +43,10 @@ app.use("/", express.static(publicDir));
 // Set fallback application options
 app.use(fallback("index.html", { root: publicDir }));
 
-// Manage search engine crawlers if staging add robots.txt, otherwise delete
-if (process.env.WEBSITE_HOSTNAME.indexOf("-stage") > -1) {
-    fs.writeFile("robots.txt", "User-agent: *\r\nDisallow: /", function (err) {
-        if (err) throw err;
-    });
-} else {
-    fs.unlink("robots.txt", function (err) {
-        if (err) throw err;
-    });
-}
+// Manage search engine crawlers, never crawl while private
+fs.writeFile("robots.txt", "User-agent: *\r\nDisallow: /", function (err) {
+    if (err) throw err;
+});
 
 // Serve up application on specified port
 var port = process.env.PORT || 7001;


### PR DESCRIPTION
# Pull Request

## 📖 Description
Always write `robots.txt` file to disallow all while private project.  When public, only write the `robots.txt` file when on staging.

Note, this change will need to be ported to the `main` branch to take effect on production's next release.  In the meantime and for testing I've made the change to the `server.js` file directly with vim.

<!--- Provide some background and a description of your work. -->

### 🎫 Issues
Middleware was looking for a `robots.txt` file when on production to delete. It could not find so the service was throwing a 503 error.  Which explains why this was only a problem in production and never in staging.

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->