### PR TITLE
Update workflow for dependency updates to use the default remote branch, removing the need to specify it

### DIFF
--- a/build/update-tooling-dependency-versions.js
+++ b/build/update-tooling-dependency-versions.js
@@ -2,14 +2,13 @@ const { exec } = require("child_process");
 const packageJson = require("../package.json");
 const fs = require("fs");
 const path = require("path");
-const { git, parseRemoteBranch } = require("workspace-tools");
+const { getDefaultRemoteBranch, git, parseRemoteBranch } = require("workspace-tools");
 
 const dependenciesToUpdate = [
     "@microsoft/fast-tooling",
     "@microsoft/fast-tooling-react"
 ];
 const cwd = path.resolve(__dirname);
-const branch = "stage";
 
 /**
  * Gets the latest version of the provided package name
@@ -159,7 +158,8 @@ async function updateDependencies () {
  * Pushes the local branch updates to the remote
  */
 function pushToRemote() {
-    const { remote, remoteBranch } = parseRemoteBranch(branch);
+    const defaultRemoteBranch = getDefaultRemoteBranch(undefined, cwd);
+    const { remote, remoteBranch } = parseRemoteBranch(defaultRemoteBranch);
     const pushArgs = ["push", "--no-verify", "--follow-tags", "--verbose", remote, `HEAD:${remoteBranch}`];
     console.log(`git ${pushArgs.join(" ")}`);
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change removes the need to specify the remote branch and will instead fetch the default remote branch.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.