### PR TITLE
Remove the message system setup logic from the preview component

### DIFF
--- a/app/preview/index.tsx
+++ b/app/preview/index.tsx
@@ -3,8 +3,11 @@ import {
     fastToolingHTMLRender,
     fastToolingHTMLRenderLayerInlineEdit,
     fastToolingHTMLRenderLayerNavigation,
+    MessageSystem,
 } from "@microsoft/fast-tooling";
+import FASTMessageSystemWorker from "@microsoft/fast-tooling/dist/message-system.min.js";
 import { fastToolingPreview } from "./web-components/preview/";
+import { Preview } from "./web-components/preview/preview";
 
 /**
  * Ensure tree-shaking doesn't remove these components from the bundle
@@ -23,3 +26,17 @@ const style: HTMLStyleElement = document.createElement("style");
 style.innerText =
     "@font-face { font-family: SegoeUIVF; src: url(https://static.fast.design/assets/fonts/SegoeUI-Roman-VF_web.ttf) format(\"truetype\"); font-weight: \"1 1000\"; } @font-face { font-family: 'Segoe UI'; src: url('//c.s-microsoft.com/static/fonts/segoe-ui/west-european/Normal/latest.woff2') format('woff2'); } body, html { font-family: SegoeUIVF, Segoe UI, SegoeUI, Helvetica Neue, Helvetica, Arial, sans-serif; font-size: 12px; padding: 0; margin: 0; }";
 document.head.appendChild(style);
+
+/**
+ * Setup the FAST tooling web worker
+ */
+const htmlRenderMessageSystemWorker: Worker = new FASTMessageSystemWorker();
+const fastMessageSystem = new MessageSystem({
+    webWorker: htmlRenderMessageSystemWorker,
+});
+
+/**
+ * Setup the Preview
+ */
+const previewWebComponent = document.querySelector("fast-tooling-preview") as Preview;
+previewWebComponent.messageSystem = fastMessageSystem;


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
As part of the effort to implement shortcuts, the message system logic for the preview component has been moved external to the component. This should facilitate both the inclusion of shortcuts, and the packaging up of the preview web component as part of FAST tooling at a later date.

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->
Begins to resolve #120

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- Add shortcuts to the preview